### PR TITLE
Splash screen, bridge sanitization, and robust user-action error handling (+ tests)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -24,7 +24,9 @@ export function createApp(dom) {
     state.mockBridge = bridgeResult.mockBridge;
 
     bindDomActions();
-    unsubscribe = subscribeToEvenEvents(state.bridge, handleEvenEvent);
+    unsubscribe = subscribeToEvenEvents(state.bridge, (event) => {
+      runUserAction(() => handleEvenEvent(event));
+    });
 
     await refreshAll({ keepPage: false, announceErrors: true });
     state.refreshTimer = window.setInterval(() => {
@@ -122,7 +124,6 @@ export function createApp(dom) {
     const eventType = textEvent?.eventType ?? sysEvent?.eventType;
 
     switch (eventType) {
-      case undefined:
       case EVENT.CLICK:
         await nextGame();
         break;
@@ -150,14 +151,23 @@ export function createApp(dom) {
 
   function bindDomActions() {
     dom.refreshButton.addEventListener('click', () => {
-      refreshAll({ keepPage: true, announceErrors: true });
+      runUserAction(() => refreshAll({ keepPage: true, announceErrors: true }));
     });
     dom.nextGameButton.addEventListener('click', () => {
-      nextGame();
+      runUserAction(nextGame);
     });
     dom.toggleSortButton.addEventListener('click', () => {
       toggleSort();
     });
+  }
+
+  function runUserAction(action) {
+    Promise.resolve()
+      .then(() => action())
+      .catch((error) => {
+        state.error = error instanceof Error ? error.message : String(error);
+        render();
+      });
   }
 
   function render() {

--- a/src/evenBridge.js
+++ b/src/evenBridge.js
@@ -25,58 +25,68 @@ export async function connectEvenBridge() {
 
 export async function pushGlassesView(bridge, started, view) {
   if (!bridge || bridge.__mock) return started;
+  const safeView = sanitizeBridgeView(view);
 
   if (!started) {
-    const result = await bridge.createStartUpPageContainer({
+    const payload = {
       containerTotalNum: 4,
       textObject: [
-        visibleContainer(CONTAINERS.header, 0, 0, DISPLAY.width, 58, view.header, 0),
-        visibleContainer(CONTAINERS.body, 0, 58, DISPLAY.width, 198, view.body, 0),
-        visibleContainer(CONTAINERS.footer, 0, 256, DISPLAY.width, 32, view.footer, 0),
+        visibleContainer(CONTAINERS.header, 0, 0, DISPLAY.width, 58, safeView.header, 0),
+        visibleContainer(CONTAINERS.body, 0, 58, DISPLAY.width, 198, safeView.body, 0),
+        visibleContainer(CONTAINERS.footer, 0, 256, DISPLAY.width, 32, safeView.footer, 0),
         captureContainer()
       ]
-    });
+    };
+    const result = await bridge.createStartUpPageContainer(payload);
 
     if (result !== 0) {
-      throw new Error(`createStartUpPageContainer failed with code ${result}`);
+      throw new Error(
+        `createStartUpPageContainer failed with code ${result}. ` +
+          'Try shortening text content and confirm container geometry matches your device profile.'
+      );
     }
 
     return true;
   }
 
-  await bridge.textContainerUpgrade({
-    containerID: CONTAINERS.header.id,
-    containerName: CONTAINERS.header.name,
-    contentOffset: 0,
-    contentLength: 2000,
-    content: view.header
-  });
-
-  await bridge.textContainerUpgrade({
-    containerID: CONTAINERS.body.id,
-    containerName: CONTAINERS.body.name,
-    contentOffset: 0,
-    contentLength: 2000,
-    content: view.body
-  });
-
-  await bridge.textContainerUpgrade({
-    containerID: CONTAINERS.footer.id,
-    containerName: CONTAINERS.footer.name,
-    contentOffset: 0,
-    contentLength: 2000,
-    content: view.footer
-  });
+  await upgradeTextContainer(bridge, CONTAINERS.header, safeView.header);
+  await upgradeTextContainer(bridge, CONTAINERS.body, safeView.body);
+  await upgradeTextContainer(bridge, CONTAINERS.footer, safeView.footer);
 
   return true;
 }
 
-export function subscribeToEvenEvents(bridge, onEvent) {
-  if (!bridge || bridge.__mock || typeof bridge.onEvenHubEvent !== 'function') {
-    return () => {};
-  }
+async function upgradeTextContainer(bridge, container, content) {
+  const result = await bridge.textContainerUpgrade({
+    containerID: container.id,
+    containerName: container.name,
+    contentOffset: 0,
+    contentLength: 2000,
+    content
+  });
 
-  return bridge.onEvenHubEvent(onEvent);
+  if (typeof result === 'number' && result !== 0) {
+    throw new Error(`textContainerUpgrade failed for ${container.name} with code ${result}`);
+  }
+}
+
+function sanitizeBridgeView(view) {
+  return {
+    header: sanitizeBridgeText(view.header, 400),
+    body: sanitizeBridgeText(view.body, 1500),
+    footer: sanitizeBridgeText(view.footer, 220)
+  };
+}
+
+function sanitizeBridgeText(text, maxLength) {
+  const safeText = String(text ?? '')
+    .replace(/•/g, '-')
+    .replace(/[^\x09\x0A\x0D\x20-\x7E]/g, '')
+    .trim();
+
+  if (safeText.length <= maxLength) return safeText;
+
+  return `${safeText.slice(0, Math.max(0, maxLength - 1))}…`;
 }
 
 function visibleContainer(container, x, y, width, height, content, capture) {
@@ -124,4 +134,12 @@ function createMockBridge() {
       return () => {};
     }
   };
+}
+
+export function subscribeToEvenEvents(bridge, onEvent) {
+  if (!bridge || bridge.__mock || typeof bridge.onEvenHubEvent !== 'function') {
+    return () => {};
+  }
+
+  return bridge.onEvenHubEvent(onEvent);
 }

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -13,3 +13,4 @@ export const CONTAINERS = {
 export const PAGE_SIZE = 7;
 export const REFRESH_INTERVAL_MS = 15_000;
 export const MAX_VISIBLE_PLAY_TEXT = 38;
+export const SPLASH_DURATION_MS = 4000;

--- a/src/lib/nbaApi.js
+++ b/src/lib/nbaApi.js
@@ -1,10 +1,17 @@
 const API_BASE = (import.meta.env?.VITE_NBA_API_BASE || '/api/nba').replace(/\/$/, '');
 
 function asNetworkErrorMessage(error) {
+  const message = error instanceof Error ? error.message : String(error);
+
   if (error instanceof TypeError) {
     return 'NBA feed unavailable (network/CORS). Use the local proxy in dev or set VITE_NBA_API_BASE for production.';
   }
-  return error instanceof Error ? error.message : String(error);
+
+  if (/did not match the expected pattern/i.test(message)) {
+    return 'NBA feed URL is invalid for this environment. Configure VITE_NBA_API_BASE to a full URL (for example: https://your-host/api/nba).';
+  }
+
+  return message;
 }
 
 export async function fetchScoreboard(fetchImpl = fetch) {

--- a/src/render.js
+++ b/src/render.js
@@ -1,7 +1,12 @@
 import { formatGameLabel, formatGameMeta, formatPageStatus, formatPlayLine } from './lib/formatters.js';
+import { SPLASH_DURATION_MS } from './lib/constants.js';
 import { pagedPlays, selectedGame } from './state.js';
 
 export function buildView(state) {
+  if (shouldShowSplash(state)) {
+    return buildSplashView(state);
+  }
+
   const game = selectedGame(state);
   const paged = pagedPlays(state);
   const headerLines = [];
@@ -57,6 +62,30 @@ export function buildView(state) {
       header: headerLines.join('\n'),
       body: bodyLines.join('\n'),
       footer: footerLines.join('\n')
+    }
+  };
+}
+
+function shouldShowSplash(state) {
+  return !state.error && Date.now() - state.launchedAt < SPLASH_DURATION_MS;
+}
+
+function buildSplashView(state) {
+  const connection = state.mockBridge ? 'Preview mode' : 'Even bridge online';
+
+  return {
+    dom: {
+      connectionStatus: state.mockBridge ? 'Browser preview (mock bridge)' : 'Connected to Even bridge',
+      selectedGame: 'NBA Pulse',
+      selectedMeta: 'Live scores + timeline',
+      timeline: '🏀 Welcome to NBA Pulse\nLoading the live scoreboard…',
+      pageStatus: 'tap next • dbl sort • scroll pages',
+      errorStatus: state.error || ''
+    },
+    glasses: {
+      header: 'NBA PULSE\nGame Night Mode',
+      body: `Connected\n${connection}\n\nLoading live scoreboard...`,
+      footer: 'tap to begin'
     }
   };
 }

--- a/src/state.js
+++ b/src/state.js
@@ -3,6 +3,7 @@ import { paginate, sortPlays } from './lib/formatters.js';
 
 export function createInitialState() {
   return {
+    launchedAt: Date.now(),
     bridge: null,
     mockBridge: true,
     started: false,

--- a/tests/app.test.mjs
+++ b/tests/app.test.mjs
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createApp } from '../src/app.js';
+
+function createButton() {
+  const handlers = new Map();
+  return {
+    addEventListener(type, handler) {
+      handlers.set(type, handler);
+    },
+    click() {
+      const handler = handlers.get('click');
+      if (handler) handler();
+    },
+    textContent: ''
+  };
+}
+
+function createDom() {
+  return {
+    refreshButton: createButton(),
+    nextGameButton: createButton(),
+    toggleSortButton: createButton(),
+    connectionStatus: { textContent: '' },
+    selectedGame: { textContent: '' },
+    selectedMeta: { textContent: '' },
+    timeline: { textContent: '' },
+    pageStatus: { textContent: '' },
+    errorStatus: { textContent: '' }
+  };
+}
+
+function jsonResponse(payload, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    async json() {
+      return payload;
+    }
+  };
+}
+
+test('nextGame click failure is caught and shown in state.error', async () => {
+  const scoreboard = {
+    scoreboard: {
+      games: [
+        {
+          gameId: 'g1',
+          gameStatus: 2,
+          gameStatusText: 'Q1 10:00',
+          homeTeam: { teamTricode: 'LAL', score: 0 },
+          awayTeam: { teamTricode: 'BOS', score: 0 }
+        },
+        {
+          gameId: 'g2',
+          gameStatus: 2,
+          gameStatusText: 'Q1 09:00',
+          homeTeam: { teamTricode: 'NYK', score: 0 },
+          awayTeam: { teamTricode: 'MIA', score: 0 }
+        }
+      ]
+    }
+  };
+
+  const playPayload = { game: { actions: [] } };
+
+  const responses = [
+    jsonResponse(scoreboard), // init scoreboard
+    jsonResponse(playPayload), // init selected game play-by-play
+    jsonResponse({}, false, 500) // nextGame fetch fails
+  ];
+
+  const originalFetch = global.fetch;
+  const originalWindow = global.window;
+
+  global.fetch = async () => {
+    if (!responses.length) {
+      throw new Error('No mocked response left');
+    }
+    return responses.shift();
+  };
+
+  global.window = {
+    setInterval() {
+      return 1;
+    },
+    clearInterval() {},
+    flutter_inappwebview: null
+  };
+
+  const dom = createDom();
+  const app = createApp(dom);
+
+  try {
+    await app.init();
+
+    dom.nextGameButton.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.match(app.state.error, /Play-by-play request failed \(500\)/);
+    assert.match(dom.errorStatus.textContent, /Play-by-play request failed \(500\)/);
+  } finally {
+    app.destroy();
+    global.fetch = originalFetch;
+    global.window = originalWindow;
+  }
+});

--- a/tests/nba.test.mjs
+++ b/tests/nba.test.mjs
@@ -5,6 +5,8 @@ import playFixture from './fixtures/playbyplay.fixture.json' with { type: 'json'
 
 import {
   chooseDefaultGameIndex,
+  fetchPlayByPlay,
+  fetchScoreboard,
   gameHasStarted,
   normalizeActions,
   normalizeGames
@@ -62,4 +64,26 @@ test('formatPlayLine produces compact timeline text', () => {
   assert.match(line, /Q3 5:11/);
   assert.match(line, /84-87/);
   assert.match(line, /Anthony Davis/);
+});
+
+test('fetchScoreboard maps invalid URL pattern errors to config guidance', async () => {
+  const fetchImpl = async () => {
+    throw new Error('The string did not match the expected pattern.');
+  };
+
+  await assert.rejects(
+    () => fetchScoreboard(fetchImpl),
+    /VITE_NBA_API_BASE to a full URL/
+  );
+});
+
+test('fetchPlayByPlay maps TypeError to network/cors guidance', async () => {
+  const fetchImpl = async () => {
+    throw new TypeError('fetch failed');
+  };
+
+  await assert.rejects(
+    () => fetchPlayByPlay('123', fetchImpl),
+    /NBA feed unavailable \(network\/CORS\)/
+  );
 });

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildView } from '../src/render.js';
+import { createInitialState } from '../src/state.js';
+import { SPLASH_DURATION_MS } from '../src/lib/constants.js';
+
+test('buildView returns splash content during initial splash window', () => {
+  const state = createInitialState();
+  state.mockBridge = false;
+
+  const view = buildView(state);
+
+  assert.match(view.glasses.header, /NBA PULSE/);
+  assert.match(view.glasses.body, /Loading live scoreboard/);
+});
+
+test('buildView exits splash mode after splash window', () => {
+  const state = createInitialState();
+  state.launchedAt = Date.now() - SPLASH_DURATION_MS - 1;
+
+  const view = buildView(state);
+
+  assert.equal(view.dom.selectedGame, 'No game selected');
+  assert.match(view.glasses.header, /NBA Pulse/);
+});


### PR DESCRIPTION
### Motivation
- Provide a brief onboarding/splash experience on launch while scoreboard loads by showing a short-lived splash view. 
- Harden interactions with the Even native bridge by sanitizing text payloads and surfacing clearer errors for bridge failures. 
- Prevent uncaught promise rejections from user-driven actions (buttons and bridge events) and surface errors in the UI. 

### Description
- Add `SPLASH_DURATION_MS` and `launchedAt` and implement splash logic in `buildView` with `shouldShowSplash` and `buildSplashView` in `src/render.js` and `src/state.js`. 
- Wrap DOM and bridge event handlers via a new `runUserAction` helper in `src/app.js` so `refreshAll`, `nextGame`, and events run in a promise chain that catches errors and updates `state.error`. 
- Refactor Even bridge interactions in `src/evenBridge.js` by creating `sanitizeBridgeView` and `sanitizeBridgeText` to strip problematic characters and enforce length limits, add `upgradeTextContainer` helper, build a `payload` before calling `createStartUpPageContainer`, and improve error messages when bridge calls fail. 
- Improve network error messaging in `src/lib/nbaApi.js` by mapping `TypeError` and invalid-URL pattern errors to actionable guidance for `VITE_NBA_API_BASE`. 
- Adjust `subscribeToEvenEvents` placement and ensure it remains exported; minor event-switch cleanup in `src/app.js`. 
- Add and update unit tests: `tests/app.test.mjs`, `tests/render.test.mjs`, and extend `tests/nba.test.mjs` with coverage for the new error-message mappings and behaviors. 

### Testing
- Ran unit test suite including `tests/app.test.mjs`, `tests/render.test.mjs`, and updated `tests/nba.test.mjs`, and all tests completed successfully. 
- Confirmed splash behavior is returned by `buildView` during the initial window and expires after `SPLASH_DURATION_MS` in `render` tests. 
- Verified error mapping behavior for `fetchScoreboard` and `fetchPlayByPlay` in `nba` tests and that UI shows caught errors after a failing `nextGame` request in `app` tests.