### PR TITLE
Support ESPN schedule and show upcoming matchups

### DIFF
--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -49,6 +49,12 @@ const server = http.createServer((req, res) => {
     return proxyFetch(`https://cdn.nba.com/static/json/liveData/playbyplay/playbyplay_${gameId}.json`, res);
   }
 
+  const scheduleMatch = req.url.match(/^\/nba\/schedule\/(\d{8})$/);
+  if (scheduleMatch) {
+    const dateKey = scheduleMatch[1];
+    return proxyFetch(`https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?dates=${dateKey}`, res);
+  }
+
   return writeJson(res, 404, { error: 'Not found' });
 });
 

--- a/src/lib/nbaApi.js
+++ b/src/lib/nbaApi.js
@@ -148,19 +148,68 @@ export function gameHasStarted(game) {
 
 export async function fetchUpcomingGames(daysAhead = 3, fetchImpl = fetch) {
   const upcoming = [];
+  const seen = new Set();
 
   for (let offset = 1; offset <= daysAhead; offset += 1) {
     const dateKey = formatDateKey(offset);
     const scoreboard = await fetchScoreboardForDate(dateKey, fetchImpl);
     const games = normalizeGames(scoreboard).filter((game) => game.gameStatus === 1);
+    const scheduledGames = normalizeScheduleEvents(
+      await fetchScheduleForDate(dateKey, fetchImpl)
+    );
 
-    for (const game of games) {
+    for (const game of [...games, ...scheduledGames]) {
+      if (seen.has(game.gameId)) continue;
+      seen.add(game.gameId);
       upcoming.push(game);
       if (upcoming.length >= 4) return upcoming;
     }
   }
 
   return upcoming;
+}
+
+function normalizeScheduleEvents(scheduleJson) {
+  const events = scheduleJson?.events ?? [];
+
+  return events
+    .map((event) => {
+      const competition = event?.competitions?.[0] ?? {};
+      const competitors = competition?.competitors ?? [];
+      const home = competitors.find((team) => team?.homeAway === 'home');
+      const away = competitors.find((team) => team?.homeAway === 'away');
+      const statusType = competition?.status?.type ?? event?.status?.type ?? {};
+      const state = String(statusType?.state || '').toLowerCase();
+      const completed = Boolean(statusType?.completed);
+
+      if (completed || state === 'post') return null;
+
+      const gameStatus = state === 'in' ? 2 : 1;
+      const gameId = String(event?.id ?? competition?.id ?? '');
+      if (!gameId) return null;
+
+      return {
+        gameDate: event?.date || '',
+        gameId,
+        gameStatus,
+        statusText: statusType?.shortDetail || statusType?.description || event?.status?.type?.shortDetail || 'Scheduled',
+        period: Number(competition?.status?.period ?? 0),
+        clock: competition?.status?.displayClock || '',
+        home: normalizeScheduleTeam(home),
+        away: normalizeScheduleTeam(away),
+        raw: event
+      };
+    })
+    .filter(Boolean);
+}
+
+function normalizeScheduleTeam(team) {
+  return {
+    id: String(team?.team?.id ?? ''),
+    code: team?.team?.abbreviation || team?.team?.shortDisplayName || 'TEAM',
+    name: team?.team?.displayName || team?.team?.shortDisplayName || 'Unknown Team',
+    score: Number(team?.score ?? 0)
+  };
 }
 
 function formatDateKey(offsetDays) {

--- a/src/render.js
+++ b/src/render.js
@@ -104,3 +104,7 @@ export function updateDom(dom, view) {
   dom.pageStatus.textContent = view.dom.pageStatus;
   dom.errorStatus.textContent = view.dom.errorStatus;
 }
+
+function formatUpcomingLine(game) {
+  return `${formatGameLabel(game)} • ${game.statusText}`;
+}


### PR DESCRIPTION
### Motivation
- The app could not show upcoming matchups when the NBA scoreboard feed lacked pregame entries because the documented `/nba/schedule/{YYYYMMDD}` proxy route was not implemented. 
- Relying only on the NBA scoreboard meant missing scheduled games that appear on ESPN's schedule endpoint. 
- The renderer also referenced an undefined helper when showing upcoming games, which could break the no-live-games UI path.

### Description
- Implemented the `/nba/schedule/:date` proxy route and pointed it at ESPN’s scoreboard-by-date API (`site.api.espn.com`) in `proxy/server.mjs` so schedule requests return JSON. 
- Updated `fetchUpcomingGames` in `src/lib/nbaApi.js` to combine pregame entries from the NBA scoreboard with events from the ESPN schedule, dedupe by `gameId`, and return a stable list of upcoming games. 
- Added `normalizeScheduleEvents` and `normalizeScheduleTeam` helpers in `src/lib/nbaApi.js` to transform ESPN schedule payloads into the app’s internal game shape. 
- Restored the missing `formatUpcomingLine` helper in `src/render.js` so the renderer can safely format upcoming matchups.

### Testing
- Ran `npm test` which executed the codebase tests and all tests passed (12/12). 
- Ran `npm run build` which produced a successful production build via `vite build` (no build errors).