### PR TITLE
Add exit confirmation UI; improve proxy & NBA API

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,2 @@
+VITE_NBA_API_BASE=https://nba-proxy.example.com/nba
+VITE_NBA_TIMEOUT_MS=8000

--- a/app.json
+++ b/app.json
@@ -15,7 +15,8 @@
       "name": "network",
       "desc": "Fetches live NBA scoreboard and play-by-play data from NBA CDN endpoints.",
       "whitelist": [
-        "https://cdn.nba.com"
+        "https://cdn.nba.com",
+        "https://nba-proxy.example.com"
       ]
     }
   ]

--- a/index.html
+++ b/index.html
@@ -19,6 +19,25 @@
         <button id="toggle-sort-btn" type="button">Sort Order</button>
       </section>
 
+      <!-- Exit confirmation dialog for preview; hidden by default -->
+      <dialog
+        id="exit-dialog"
+        aria-labelledby="exit-dialog-title"
+        aria-describedby="exit-dialog-copy"
+      >
+        <div class="dialog-form">
+          <h2 id="exit-dialog-title">Exit NBA Pulse?</h2>
+          <p id="exit-dialog-copy">
+            Double-click opened exit confirmation. Choose Cancel to stay
+            or Exit app to leave.
+          </p>
+          <div class="dialog-actions">
+            <button id="exit-cancel-btn" type="button" autofocus>Cancel</button>
+            <button id="exit-confirm-btn" type="button">Exit app</button>
+          </div>
+        </div>
+      </dialog>
+
       <section class="summary-card">
         <div id="selected-game">Loading Scoreboard…</div>
         <div id="selected-meta"></div>

--- a/proxy/server.mjs
+++ b/proxy/server.mjs
@@ -2,6 +2,7 @@ import http from 'node:http';
 
 const PORT = process.env.PORT || 8787;
 const ALLOW_ORIGIN = process.env.ALLOW_ORIGIN || '*';
+const FETCH_TIMEOUT_MS = Number(process.env.FETCH_TIMEOUT_MS || 8000);
 
 function writeJson(res, status, data) {
   res.writeHead(status, {
@@ -13,9 +14,19 @@ function writeJson(res, status, data) {
   res.end(JSON.stringify(data));
 }
 
-async function proxyFetch(url, res) {
+function logProxy(entry) {
+  console.log(JSON.stringify({ at: new Date().toISOString(), ...entry }));
+}
+
+async function proxyFetch(sourcePath, targetUrl, res) {
+  const startedAt = Date.now();
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
-    const response = await fetch(url, { headers: { 'user-agent': 'even-nba-pulse-proxy/1.0' } });
+    const response = await fetch(targetUrl, {
+      headers: { 'user-agent': 'even-nba-pulse-proxy/1.0' },
+      signal: controller.signal
+    });
     const text = await response.text();
     res.writeHead(response.status, {
       'content-type': 'application/json; charset=utf-8',
@@ -24,8 +35,24 @@ async function proxyFetch(url, res) {
       'access-control-allow-headers': 'content-type'
     });
     res.end(text);
+    logProxy({
+      sourcePath,
+      targetUrl,
+      status: response.status,
+      durationMs: Date.now() - startedAt
+    });
   } catch (error) {
-    writeJson(res, 502, { error: error instanceof Error ? error.message : String(error) });
+    const status = error?.name === 'AbortError' ? 504 : 502;
+    logProxy({
+      sourcePath,
+      targetUrl,
+      status,
+      durationMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    writeJson(res, status, { error: error instanceof Error ? error.message : String(error) });
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 
@@ -34,25 +61,41 @@ const server = http.createServer((req, res) => {
   if (req.method === 'OPTIONS') return writeJson(res, 204, {});
 
   if (req.url === '/nba/scoreboard') {
-    return proxyFetch('https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json', res);
+    return proxyFetch(
+      req.url,
+      'https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json',
+      res
+    );
   }
 
   const scoreboardByDateMatch = req.url.match(/^\/nba\/scoreboard\/(\d{8})$/);
   if (scoreboardByDateMatch) {
     const gameDate = scoreboardByDateMatch[1];
-    return proxyFetch(`https://cdn.nba.com/static/json/liveData/scoreboard/scoreboard_${gameDate}.json`, res);
+    return proxyFetch(
+      req.url,
+      `https://cdn.nba.com/static/json/liveData/scoreboard/scoreboard_${gameDate}.json`,
+      res
+    );
   }
 
   const playMatch = req.url.match(/^\/nba\/playbyplay\/([^/]+)$/);
   if (playMatch) {
     const gameId = playMatch[1];
-    return proxyFetch(`https://cdn.nba.com/static/json/liveData/playbyplay/playbyplay_${gameId}.json`, res);
+    return proxyFetch(
+      req.url,
+      `https://cdn.nba.com/static/json/liveData/playbyplay/playbyplay_${gameId}.json`,
+      res
+    );
   }
 
   const scheduleMatch = req.url.match(/^\/nba\/schedule\/(\d{8})$/);
   if (scheduleMatch) {
     const dateKey = scheduleMatch[1];
-    return proxyFetch(`https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?dates=${dateKey}`, res);
+    return proxyFetch(
+      req.url,
+      `https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?dates=${dateKey}`,
+      res
+    );
   }
 
   return writeJson(res, 404, { error: 'Not found' });

--- a/src/app.js
+++ b/src/app.js
@@ -102,6 +102,8 @@ export function createApp(dom) {
   }
 
   async function nextGame() {
+    // Prevent switching games while exit confirmation is open
+    if (state.confirmExitOpen) return;
     if (!state.games.length) return;
     state.selectedGameIndex = (state.selectedGameIndex + 1) % state.games.length;
     state.selectedGameId = state.games[state.selectedGameIndex].gameId;
@@ -111,6 +113,8 @@ export function createApp(dom) {
   }
 
   function toggleSort() {
+    // Ignore sort toggles while exit confirmation is open
+    if (state.confirmExitOpen) return;
     state.sortDirection = state.sortDirection === 'desc' ? 'asc' : 'desc';
     state.pageIndex = 0;
     render();
@@ -123,8 +127,49 @@ export function createApp(dom) {
   }
 
   function prevPage() {
+    if (state.confirmExitOpen) {
+      closeExitConfirmation();
+      return;
+    }
     state.pageIndex = Math.max(state.pageIndex - 1, 0);
     render();
+  }
+
+  // Show exit confirmation overlay. Ignored if already open.
+  function openExitConfirmation() {
+    if (state.confirmExitOpen) return;
+    state.confirmExitOpen = true;
+    render();
+  }
+
+  // Close exit confirmation overlay if open.
+  function closeExitConfirmation() {
+    if (!state.confirmExitOpen) return;
+    state.confirmExitOpen = false;
+    render();
+  }
+
+  // Request the host or browser to exit the application. This fallback uses window history or
+  // window.close() and sets an error if not available.
+  function requestExit() {
+    // Replace this stub with Even-specific exit API when available.
+    if (window.history.length > 1) {
+      window.history.back();
+      return;
+    }
+    if (typeof window.close === 'function') {
+      window.close();
+      return;
+    }
+    state.error =
+      'Exit was confirmed, but no host close action is available. ' +
+      'Replace requestExit() with the Even host close API if your bridge exposes one.';
+    render();
+  }
+
+  async function confirmExit() {
+    closeExitConfirmation();
+    requestExit();
   }
 
   async function handleEvenEvent(event) {
@@ -132,12 +177,34 @@ export function createApp(dom) {
 
     if (eventType == null) return;
 
+    // When exit confirmation is open, interpret events as confirm/cancel actions
+    if (state.confirmExitOpen) {
+      switch (eventType) {
+        case EVENT.CLICK:
+          await confirmExit();
+          break;
+        case EVENT.DOUBLE_CLICK:
+        case EVENT.SCROLL_TOP:
+        case EVENT.SCROLL_BOTTOM:
+          closeExitConfirmation();
+          break;
+        case EVENT.FOREGROUND_EXIT:
+        case EVENT.ABNORMAL_EXIT:
+          state.visible = false;
+          closeExitConfirmation();
+          break;
+        default:
+          break;
+      }
+      return;
+    }
+
     switch (eventType) {
       case EVENT.CLICK:
         await nextGame();
         break;
       case EVENT.DOUBLE_CLICK:
-        toggleSort();
+        openExitConfirmation();
         break;
       case EVENT.SCROLL_BOTTOM:
         nextPage();
@@ -168,6 +235,26 @@ export function createApp(dom) {
     dom.toggleSortButton.addEventListener('click', () => {
       toggleSort();
     });
+
+    // Attach handlers for exit confirmation dialog if present
+    if (dom.exitCancelButton) {
+      dom.exitCancelButton.addEventListener('click', () => {
+        closeExitConfirmation();
+      });
+    }
+
+    if (dom.exitConfirmButton) {
+      dom.exitConfirmButton.addEventListener('click', () => {
+        runUserAction(confirmExit);
+      });
+    }
+
+    if (dom.exitDialog) {
+      dom.exitDialog.addEventListener('cancel', (event) => {
+        event.preventDefault();
+        closeExitConfirmation();
+      });
+    }
   }
 
   function runUserAction(action) {
@@ -182,6 +269,7 @@ export function createApp(dom) {
   function render() {
     const view = buildView(state);
     updateDom(dom, view);
+    syncExitDialog();
     pushGlassesView(state.bridge, state.started, view.glasses)
       .then((started) => {
         state.started = started;
@@ -190,6 +278,18 @@ export function createApp(dom) {
         state.error = error instanceof Error ? error.message : String(error);
         updateDom(dom, buildView(state));
       });
+  }
+
+  // Synchronize the state.confirmExitOpen with the native dialog element, opening or closing as needed.
+  function syncExitDialog() {
+    if (!dom.exitDialog) return;
+    if (state.confirmExitOpen && !dom.exitDialog.open) {
+      dom.exitDialog.showModal();
+      return;
+    }
+    if (!state.confirmExitOpen && dom.exitDialog.open) {
+      dom.exitDialog.close();
+    }
   }
 
   function destroy() {

--- a/src/dom.js
+++ b/src/dom.js
@@ -8,6 +8,10 @@ export function mountDom() {
     errorStatus: document.querySelector('#error-status'),
     refreshButton: document.querySelector('#refresh-btn'),
     nextGameButton: document.querySelector('#next-game-btn'),
-    toggleSortButton: document.querySelector('#toggle-sort-btn')
+    toggleSortButton: document.querySelector('#toggle-sort-btn'),
+    // Exit confirmation dialog and buttons
+    exitDialog: document.querySelector('#exit-dialog'),
+    exitCancelButton: document.querySelector('#exit-cancel-btn'),
+    exitConfirmButton: document.querySelector('#exit-confirm-btn')
   };
 }

--- a/src/lib/nbaApi.js
+++ b/src/lib/nbaApi.js
@@ -1,86 +1,101 @@
-const API_BASE = (import.meta.env?.VITE_NBA_API_BASE || '/api/nba').replace(/\/$/, '');
+// Choose a default base for dev builds; require explicit VITE_NBA_API_BASE in production.
+const DEFAULT_API_BASE = import.meta.env.DEV ? '/api/nba' : '';
+const API_BASE = (import.meta.env?.VITE_NBA_API_BASE || DEFAULT_API_BASE).replace(/\/$/, '');
+// Timeout for fetch requests in milliseconds. Can be configured via VITE_NBA_TIMEOUT_MS.
+const REQUEST_TIMEOUT_MS = Number(import.meta.env?.VITE_NBA_TIMEOUT_MS || 8000);
+// Use performance.now if available for higher resolution timing
+const now = () => globalThis.performance?.now?.() ?? Date.now();
 
-function asNetworkErrorMessage(error) {
-  const message = error instanceof Error ? error.message : String(error);
-
-  if (error instanceof TypeError) {
-    return 'NBA feed unavailable (network/CORS). Use the local proxy in dev or set VITE_NBA_API_BASE for production.';
+function buildApiUrl(path) {
+  if (!API_BASE) {
+    throw new Error(
+      'VITE_NBA_API_BASE is required for production builds. ' +
+      'Example: https://nba-proxy.example.com/nba'
+    );
   }
+  return `${API_BASE}/${path}`;
+}
 
-  if (/did not match the expected pattern/i.test(message)) {
+function asNetworkErrorMessage(error, context = {}) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (error?.name === 'AbortError') {
+    return `NBA feed timed out while requesting ${context.url || context.label || 'the feed'}.`;
+  }
+  if (globalThis.navigator?.onLine === false) {
+    return 'Device appears offline. Reconnect and try again.';
+  }
+  if (error instanceof TypeError) {
+    return (
+      `NBA feed unavailable (network/CORS) at ${context.url || 'configured endpoint'}. ` +
+      'Use the local proxy in dev or set VITE_NBA_API_BASE for production.'
+    );
+  }
+  if (/did not match the expected pattern/i.test(message) || /Invalid URL/.test(message)) {
     return 'NBA feed URL is invalid for this environment. Configure VITE_NBA_API_BASE to a full URL (for example: https://your-host/api/nba).';
   }
-
   return message;
 }
 
+async function fetchJson(path, label, notFoundValue, fetchImpl = fetch) {
+  const url = buildApiUrl(path);
+  const controller = new AbortController();
+  const startedAt = now();
+  const timeoutId = globalThis.setTimeout(() => controller.abort('timeout'), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(url, {
+      cache: 'no-store',
+      headers: { accept: 'application/json' },
+      signal: controller.signal
+    });
+    if (response.status === 404) {
+      return notFoundValue;
+    }
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(
+        `${label} request failed (${response.status})` +
+        (body ? `: ${body.slice(0, 160)}` : '')
+      );
+    }
+    return response.json();
+  } catch (error) {
+    console.error('[nbaApi]', { label, url, error });
+    throw new Error(asNetworkErrorMessage(error, { label, url }));
+  } finally {
+    globalThis.clearTimeout(timeoutId);
+    console.debug('[nbaApi]', label, Math.round(now() - startedAt), 'ms', url);
+  }
+}
+
 export async function fetchScoreboard(fetchImpl = fetch) {
-  return fetchScoreboardByPath('scoreboard', fetchImpl);
+  return fetchJson('scoreboard', 'scoreboard', { scoreboard: { games: [] } }, fetchImpl);
 }
 
 export async function fetchScoreboardForDate(dateKey, fetchImpl = fetch) {
-  return fetchScoreboardByPath(`scoreboard/${dateKey}`, fetchImpl);
-}
-
-async function fetchScoreboardByPath(path, fetchImpl = fetch) {
-  try {
-    const response = await fetchImpl(`${API_BASE}/${path}`, {
-      cache: 'no-store'
-    });
-
-    if (response.status === 404) {
-      return { scoreboard: { games: [] } };
-    }
-
-    if (!response.ok) {
-      throw new Error(`Scoreboard request failed (${response.status})`);
-    }
-
-    return response.json();
-  } catch (error) {
-    throw new Error(asNetworkErrorMessage(error));
-  }
+  return fetchJson(
+    `scoreboard/${dateKey}`,
+    `scoreboard/${dateKey}`,
+    { scoreboard: { games: [] } },
+    fetchImpl
+  );
 }
 
 export async function fetchPlayByPlay(gameId, fetchImpl = fetch) {
-  try {
-    const response = await fetchImpl(
-      `${API_BASE}/playbyplay/${gameId}`,
-      { cache: 'no-store' }
-    );
-
-    if (response.status === 404) {
-      return { game: { actions: [] } };
-    }
-
-    if (!response.ok) {
-      throw new Error(`Play-by-play request failed (${response.status})`);
-    }
-
-    return response.json();
-  } catch (error) {
-    throw new Error(asNetworkErrorMessage(error));
-  }
+  return fetchJson(
+    `playbyplay/${gameId}`,
+    `playbyplay/${gameId}`,
+    { game: { actions: [] } },
+    fetchImpl
+  );
 }
 
 export async function fetchScheduleForDate(dateKey, fetchImpl = fetch) {
-  try {
-    const response = await fetchImpl(`${API_BASE}/schedule/${dateKey}`, {
-      cache: 'no-store'
-    });
-
-    if (response.status === 404) {
-      return { events: [] };
-    }
-
-    if (!response.ok) {
-      throw new Error(`Schedule request failed (${response.status})`);
-    }
-
-    return response.json();
-  } catch (error) {
-    throw new Error(asNetworkErrorMessage(error));
-  }
+  return fetchJson(
+    `schedule/${dateKey}`,
+    `schedule/${dateKey}`,
+    { events: [] },
+    fetchImpl
+  );
 }
 
 export function normalizeGames(scoreboardJson) {
@@ -152,11 +167,24 @@ export async function fetchUpcomingGames(daysAhead = 3, fetchImpl = fetch) {
 
   for (let offset = 1; offset <= daysAhead; offset += 1) {
     const dateKey = formatDateKey(offset);
-    const scoreboard = await fetchScoreboardForDate(dateKey, fetchImpl);
-    const games = normalizeGames(scoreboard).filter((game) => game.gameStatus === 1);
-    const scheduledGames = normalizeScheduleEvents(
-      await fetchScheduleForDate(dateKey, fetchImpl)
-    );
+    const [scoreboardResult, scheduleResult] = await Promise.allSettled([
+      fetchScoreboardForDate(dateKey, fetchImpl),
+      fetchScheduleForDate(dateKey, fetchImpl)
+    ]);
+
+    if (scoreboardResult.status === 'rejected' && scheduleResult.status === 'rejected') {
+      throw scoreboardResult.reason;
+    }
+
+    const games =
+      scoreboardResult.status === 'fulfilled'
+        ? normalizeGames(scoreboardResult.value).filter((game) => game.gameStatus === 1)
+        : [];
+
+    const scheduledGames =
+      scheduleResult.status === 'fulfilled'
+        ? normalizeScheduleEvents(scheduleResult.value)
+        : [];
 
     for (const game of [...games, ...scheduledGames]) {
       if (seen.has(game.gameId)) continue;

--- a/src/render.js
+++ b/src/render.js
@@ -8,6 +8,11 @@ import { SPLASH_DURATION_MS } from './lib/constants.js';
 import { pagedPlays, selectedGame } from './state.js';
 
 export function buildView(state) {
+  // Show exit confirmation overlay if requested
+  if (state.confirmExitOpen) {
+    return buildExitConfirmationView(state);
+  }
+
   if (shouldShowSplash(state)) {
     return buildSplashView(state);
   }
@@ -280,4 +285,35 @@ function escapeHtml(value) {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+}
+
+// Build view for exit confirmation state. This renders a minimal preview and glasses view.
+function buildExitConfirmationView(state) {
+  return {
+    dom: {
+      connectionStatus: state.mockBridge
+        ? 'Browser preview (mock bridge)'
+        : 'Connected to Even bridge',
+      selectedGame: 'Exit NBA Pulse?',
+      selectedMeta: 'Click to confirm • Scroll / double-click to cancel',
+      timeline: '',
+      timelineHtml: `
+        <div class="empty-title">Exit confirmation</div>
+        <div class="empty-copy">
+          Double-click opened confirmation. Click to exit, or scroll /
+          double-click to stay in the app.
+        </div>
+      `,
+      pageStatus: 'click exit • scroll cancel',
+      errorStatus: state.error || '',
+      summaryClass: 'summary-card is-empty',
+      timelineClass: 'timeline-card is-empty',
+      footerClass: 'footer-card'
+    },
+    glasses: {
+      header: 'NBA PULSE',
+      body: 'Exit app?\nClick = exit\nScroll = cancel',
+      footer: 'Confirm exit'
+    }
+  };
 }

--- a/src/state.js
+++ b/src/state.js
@@ -16,6 +16,8 @@ export function createInitialState() {
     plays: [],
     sortDirection: 'desc',
     pageIndex: 0,
+    // Whether the exit confirmation is open
+    confirmExitOpen: false,
     refreshTimer: null,
     lastUpdatedAt: null,
     visible: true

--- a/src/styles.css
+++ b/src/styles.css
@@ -116,6 +116,40 @@ button:focus-visible {
   outline-offset: 2px;
 }
 
+/* Styles for native dialog used in preview exit confirmation */
+dialog {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  background: var(--panel);
+  color: var(--text);
+  max-width: 420px;
+  width: calc(100% - 32px);
+  padding: 0;
+  box-shadow: var(--shadow-lg);
+}
+
+dialog::backdrop {
+  background: rgba(0, 0, 0, 0.56);
+}
+
+.dialog-form {
+  display: grid;
+  gap: var(--space-4);
+  padding: var(--space-5);
+}
+
+.dialog-form h2,
+.dialog-form p {
+  margin: 0;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
 #next-game-btn {
   background: linear-gradient(180deg, rgba(100, 181, 246, 0.16), rgba(100, 181, 246, 0.08));
   border-color: rgba(100, 181, 246, 0.42);


### PR DESCRIPTION
## Summary

Introduce an exit confirmation dialog and wire it into app state and UI, and harden proxy + NBA API network handling.

- UI: add native <dialog> markup (index.html), dialog styling (styles.css), and DOM bindings (src/dom.js). Render an exit confirmation view (src/render.js) and synchronize dialog open/close with state. Add buttons and handlers to open, close and confirm exit in src/app.js, plus a small fallback requestExit() stub.
- State: add confirmExitOpen flag to state (src/state.js) and guard navigation/sort interactions when confirmation is open.
- Proxy: add FETCH_TIMEOUT_MS, abort support, structured logging, and improved request routing with sourcePath for better observability (proxy/server.mjs).
- NBA API: refactor to use a single fetchJson helper with AbortController and configurable REQUEST_TIMEOUT_MS, improved error messages and logging, enforce VITE_NBA_API_BASE in production, and use Promise.allSettled when fetching upcoming games to tolerate partial failures (src/lib/nbaApi.js).
- Misc: add .env.production.example with recommended variables and update app.json whitelist to include the proxy host.

These changes improve UX for preview/host exit flows and make network requests more reliable and observable.