### PR TITLE
fix: Implement play-by-play normalization for NBA CDN

### DIFF
--- a/change.diff
+++ b/change.diff
@@ -1,0 +1,27 @@
+﻿diff --git a/src/lib/nbaApi.js b/src/lib/nbaApi.js
+index abe29d3..bf6e9d6 100644
+--- a/src/lib/nbaApi.js
++++ b/src/lib/nbaApi.js
+@@ -146,8 +146,20 @@ function normalizeTeamNba(team) {
+ }
+ 
+ export function normalizeActions(playJson) {
+-  // Play-by-play not available via ESPN - return empty array
+-  return [];
++  // NBA CDN play-by-play structure: game.actions array
++  const actions = playJson?.game?.actions || [];
++  
++  return actions
++    .filter(action => action.description) // Skip events without descriptions
++    .map((action, index) => ({
++      actionNumber: action.actionNumber || index,
++      period: action.period || 1,
++      clock: action.gameClock || '',
++      description: action.description || '',
++      awayScore: action.scoreAway ?? action.awayScore ?? 0,
++      homeScore: action.scoreHome ?? action.homeScore ?? 0,
++      order: action.order ?? action.actionNumber ?? index
++    }));
+ }
+ 
+ export function chooseDefaultGameIndex(games) {

--- a/src/lib/nbaApi.js
+++ b/src/lib/nbaApi.js
@@ -146,8 +146,20 @@ function normalizeTeamNba(team) {
 }
 
 export function normalizeActions(playJson) {
-  // Play-by-play not available via ESPN - return empty array
-  return [];
+  // NBA CDN play-by-play structure: game.actions array
+  const actions = playJson?.game?.actions || [];
+  
+  return actions
+    .filter(action => action.description) // Skip events without descriptions
+    .map((action, index) => ({
+      actionNumber: action.actionNumber || index,
+      period: action.period || 1,
+      clock: action.gameClock || '',
+      description: action.description || '',
+      awayScore: action.scoreAway ?? action.awayScore ?? 0,
+      homeScore: action.scoreHome ?? action.homeScore ?? 0,
+      order: action.order ?? action.actionNumber ?? index
+    }));
 }
 
 export function chooseDefaultGameIndex(games) {

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,0 +1,92 @@
+// Cloudflare Worker for NBA CORS proxy
+// Routes: /nba/scoreboard, /nba/scoreboard/:date, /nba/playbyplay/:gameId, /nba/schedule/:date
+
+const ALLOW_ORIGIN = '*';
+const FETCH_TIMEOUT_MS = 8000;
+
+function logProxy(entry) {
+  console.log(JSON.stringify({ at: new Date().toISOString(), ...entry }));
+}
+
+async function handleRequest(request) {
+  const url = new URL(request.url);
+  const path = url.pathname;
+
+  // Handle CORS preflight
+  if (request.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'access-control-allow-origin': ALLOW_ORIGIN,
+        'access-control-allow-methods': 'GET,OPTIONS',
+        'access-control-allow-headers': 'content-type'
+      }
+    });
+  }
+
+  let targetUrl;
+
+  if (path === '/nba/scoreboard') {
+    targetUrl = 'https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json';
+  } else if (path.match(/^\/nba\/scoreboard\/\d{8}$/)) {
+    const gameDate = path.split('/').pop();
+    targetUrl = `https://cdn.nba.com/static/json/liveData/scoreboard/scoreboard_${gameDate}.json`;
+  } else if (path.match(/^\/nba\/playbyplay\/[^/]+$/)) {
+    const gameId = path.split('/').pop();
+    targetUrl = `https://cdn.nba.com/static/json/liveData/playbyplay/playbyplay_${gameId}.json`;
+  } else if (path.match(/^\/nba\/schedule\/\d{8}$/)) {
+    const dateKey = path.split('/').pop();
+    targetUrl = `https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?dates=${dateKey}`;
+  } else {
+    return new Response(JSON.stringify({ error: 'Not found' }), {
+      status: 404,
+      headers: { 'content-type': 'application/json' }
+    });
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(targetUrl, {
+      headers: { 'user-agent': 'even-nba-pulse-proxy/1.0' },
+      signal: controller.signal
+    });
+
+    const body = await response.text();
+    const headers = new Headers(response.headers);
+    headers.set('access-control-allow-origin', ALLOW_ORIGIN);
+    headers.set('access-control-allow-methods', 'GET,OPTIONS');
+    headers.set('access-control-allow-headers', 'content-type');
+
+    logProxy({
+      sourcePath: path,
+      targetUrl,
+      status: response.status
+    });
+
+    return new Response(body, {
+      status: response.status,
+      headers
+    });
+  } catch (error) {
+    const status = error?.name === 'AbortError' ? 504 : 502;
+    logProxy({
+      sourcePath: path,
+      targetUrl,
+      status,
+      error: error instanceof Error ? error.message : String(error)
+    });
+
+    return new Response(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }), {
+      status,
+      headers: { 'content-type': 'application/json', 'access-control-allow-origin': ALLOW_ORIGIN }
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+addEventListener('fetch', event => {
+  event.respondWith(handleRequest(event.request));
+});

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,92 +1,87 @@
-// Cloudflare Worker for NBA CORS proxy
+// Cloudflare Worker (ES Modules) for NBA CORS proxy
 // Routes: /nba/scoreboard, /nba/scoreboard/:date, /nba/playbyplay/:gameId, /nba/schedule/:date
 
-const ALLOW_ORIGIN = '*';
-const FETCH_TIMEOUT_MS = 8000;
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    const path = url.pathname;
+    const ALLOW_ORIGIN = '*';
+    const FETCH_TIMEOUT_MS = 8000;
 
-function logProxy(entry) {
-  console.log(JSON.stringify({ at: new Date().toISOString(), ...entry }));
-}
+    // Handle CORS preflight
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 204,
+        headers: {
+          'access-control-allow-origin': ALLOW_ORIGIN,
+          'access-control-allow-methods': 'GET,OPTIONS',
+          'access-control-allow-headers': 'content-type'
+        }
+      });
+    }
 
-async function handleRequest(request) {
-  const url = new URL(request.url);
-  const path = url.pathname;
+    let targetUrl;
 
-  // Handle CORS preflight
-  if (request.method === 'OPTIONS') {
-    return new Response(null, {
-      status: 204,
-      headers: {
-        'access-control-allow-origin': ALLOW_ORIGIN,
-        'access-control-allow-methods': 'GET,OPTIONS',
-        'access-control-allow-headers': 'content-type'
-      }
-    });
+    if (path === '/nba/scoreboard') {
+      targetUrl = 'https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json';
+    } else if (path.match(/^\/nba\/scoreboard\/\d{8}$/)) {
+      const gameDate = path.split('/').pop();
+      targetUrl = `https://cdn.nba.com/static/json/liveData/scoreboard/scoreboard_${gameDate}.json`;
+    } else if (path.match(/^\/nba\/playbyplay\/[^/]+$/)) {
+      const gameId = path.split('/').pop();
+      targetUrl = `https://cdn.nba.com/static/json/liveData/playbyplay/playbyplay_${gameId}.json`;
+    } else if (path.match(/^\/nba\/schedule\/\d{8}$/)) {
+      const dateKey = path.split('/').pop();
+      targetUrl = `https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?dates=${dateKey}`;
+    } else {
+      return new Response(JSON.stringify({ error: 'Not found' }), {
+        status: 404,
+        headers: { 'content-type': 'application/json' }
+      });
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(targetUrl, {
+        headers: { 'user-agent': 'even-nba-pulse-proxy/1.0' },
+        signal: controller.signal
+      });
+
+      const body = await response.text();
+      const headers = new Headers(response.headers);
+      headers.set('access-control-allow-origin', ALLOW_ORIGIN);
+      headers.set('access-control-allow-methods', 'GET,OPTIONS');
+      headers.set('access-control-allow-headers', 'content-type');
+
+      console.log(JSON.stringify({
+        at: new Date().toISOString(),
+        sourcePath: path,
+        targetUrl,
+        status: response.status
+      }));
+
+      return new Response(body, {
+        status: response.status,
+        headers
+      });
+    } catch (error) {
+      const status = error?.name === 'AbortError' ? 504 : 502;
+      console.log(JSON.stringify({
+        at: new Date().toISOString(),
+        sourcePath: path,
+        targetUrl,
+        status,
+        error: error instanceof Error ? error.message : String(error)
+      }));
+
+      return new Response(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }), {
+        status,
+        headers: { 'content-type': 'application/json', 'access-control-allow-origin': ALLOW_ORIGIN }
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
   }
-
-  let targetUrl;
-
-  if (path === '/nba/scoreboard') {
-    targetUrl = 'https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json';
-  } else if (path.match(/^\/nba\/scoreboard\/\d{8}$/)) {
-    const gameDate = path.split('/').pop();
-    targetUrl = `https://cdn.nba.com/static/json/liveData/scoreboard/scoreboard_${gameDate}.json`;
-  } else if (path.match(/^\/nba\/playbyplay\/[^/]+$/)) {
-    const gameId = path.split('/').pop();
-    targetUrl = `https://cdn.nba.com/static/json/liveData/playbyplay/playbyplay_${gameId}.json`;
-  } else if (path.match(/^\/nba\/schedule\/\d{8}$/)) {
-    const dateKey = path.split('/').pop();
-    targetUrl = `https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?dates=${dateKey}`;
-  } else {
-    return new Response(JSON.stringify({ error: 'Not found' }), {
-      status: 404,
-      headers: { 'content-type': 'application/json' }
-    });
-  }
-
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
-  try {
-    const response = await fetch(targetUrl, {
-      headers: { 'user-agent': 'even-nba-pulse-proxy/1.0' },
-      signal: controller.signal
-    });
-
-    const body = await response.text();
-    const headers = new Headers(response.headers);
-    headers.set('access-control-allow-origin', ALLOW_ORIGIN);
-    headers.set('access-control-allow-methods', 'GET,OPTIONS');
-    headers.set('access-control-allow-headers', 'content-type');
-
-    logProxy({
-      sourcePath: path,
-      targetUrl,
-      status: response.status
-    });
-
-    return new Response(body, {
-      status: response.status,
-      headers
-    });
-  } catch (error) {
-    const status = error?.name === 'AbortError' ? 504 : 502;
-    logProxy({
-      sourcePath: path,
-      targetUrl,
-      status,
-      error: error instanceof Error ? error.message : String(error)
-    });
-
-    return new Response(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }), {
-      status,
-      headers: { 'content-type': 'application/json', 'access-control-allow-origin': ALLOW_ORIGIN }
-    });
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
-
-addEventListener('fetch', event => {
-  event.respondWith(handleRequest(event.request));
-});
+};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+  "name": "nba-pulse-proxy",
+  "compatibility_date": "2026-04-25",
+  "main": "worker/index.js"
+}


### PR DESCRIPTION
- Replace empty stub with actual NBA action mapping
- Extract game.actions array from play-by-play response
- Map actionNumber, period, clock, description, scores
- Filter out events without descriptions
- Fallback handling for missing fields

Fixes cloudflare worker integration where play-by-play data was being fetched but not normalized.