### PR TITLE
Fix/play by play normalization

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "package_id": "com.openai.nbapulse",
   "edition": "202601",
   "name": "NBA Pulse",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "min_app_version": "2.0.0",
   "min_sdk_version": "0.0.9",
   "entrypoint": "index.html",

--- a/change.diff
+++ b/change.diff
@@ -1,0 +1,27 @@
+﻿diff --git a/src/lib/nbaApi.js b/src/lib/nbaApi.js
+index abe29d3..bf6e9d6 100644
+--- a/src/lib/nbaApi.js
++++ b/src/lib/nbaApi.js
+@@ -146,8 +146,20 @@ function normalizeTeamNba(team) {
+ }
+ 
+ export function normalizeActions(playJson) {
+-  // Play-by-play not available via ESPN - return empty array
+-  return [];
++  // NBA CDN play-by-play structure: game.actions array
++  const actions = playJson?.game?.actions || [];
++  
++  return actions
++    .filter(action => action.description) // Skip events without descriptions
++    .map((action, index) => ({
++      actionNumber: action.actionNumber || index,
++      period: action.period || 1,
++      clock: action.gameClock || '',
++      description: action.description || '',
++      awayScore: action.scoreAway ?? action.awayScore ?? 0,
++      homeScore: action.scoreHome ?? action.homeScore ?? 0,
++      order: action.order ?? action.actionNumber ?? index
++    }));
+ }
+ 
+ export function chooseDefaultGameIndex(games) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "even-nba-pulse",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/lib/nbaApi.js
+++ b/src/lib/nbaApi.js
@@ -146,8 +146,20 @@ function normalizeTeamNba(team) {
 }
 
 export function normalizeActions(playJson) {
-  // Play-by-play not available via ESPN - return empty array
-  return [];
+  // NBA CDN play-by-play structure: game.actions array
+  const actions = playJson?.game?.actions || [];
+  
+  return actions
+    .filter(action => action.description) // Skip events without descriptions
+    .map((action, index) => ({
+      actionNumber: action.actionNumber || index,
+      period: action.period || 1,
+      clock: action.gameClock || '',
+      description: action.description || '',
+      awayScore: action.scoreAway ?? action.awayScore ?? 0,
+      homeScore: action.scoreHome ?? action.homeScore ?? 0,
+      order: action.order ?? action.actionNumber ?? index
+    }));
 }
 
 export function chooseDefaultGameIndex(games) {

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,0 +1,92 @@
+// Cloudflare Worker for NBA CORS proxy
+// Routes: /nba/scoreboard, /nba/scoreboard/:date, /nba/playbyplay/:gameId, /nba/schedule/:date
+
+const ALLOW_ORIGIN = '*';
+const FETCH_TIMEOUT_MS = 8000;
+
+function logProxy(entry) {
+  console.log(JSON.stringify({ at: new Date().toISOString(), ...entry }));
+}
+
+async function handleRequest(request) {
+  const url = new URL(request.url);
+  const path = url.pathname;
+
+  // Handle CORS preflight
+  if (request.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'access-control-allow-origin': ALLOW_ORIGIN,
+        'access-control-allow-methods': 'GET,OPTIONS',
+        'access-control-allow-headers': 'content-type'
+      }
+    });
+  }
+
+  let targetUrl;
+
+  if (path === '/nba/scoreboard') {
+    targetUrl = 'https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json';
+  } else if (path.match(/^\/nba\/scoreboard\/\d{8}$/)) {
+    const gameDate = path.split('/').pop();
+    targetUrl = `https://cdn.nba.com/static/json/liveData/scoreboard/scoreboard_${gameDate}.json`;
+  } else if (path.match(/^\/nba\/playbyplay\/[^/]+$/)) {
+    const gameId = path.split('/').pop();
+    targetUrl = `https://cdn.nba.com/static/json/liveData/playbyplay/playbyplay_${gameId}.json`;
+  } else if (path.match(/^\/nba\/schedule\/\d{8}$/)) {
+    const dateKey = path.split('/').pop();
+    targetUrl = `https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?dates=${dateKey}`;
+  } else {
+    return new Response(JSON.stringify({ error: 'Not found' }), {
+      status: 404,
+      headers: { 'content-type': 'application/json' }
+    });
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(targetUrl, {
+      headers: { 'user-agent': 'even-nba-pulse-proxy/1.0' },
+      signal: controller.signal
+    });
+
+    const body = await response.text();
+    const headers = new Headers(response.headers);
+    headers.set('access-control-allow-origin', ALLOW_ORIGIN);
+    headers.set('access-control-allow-methods', 'GET,OPTIONS');
+    headers.set('access-control-allow-headers', 'content-type');
+
+    logProxy({
+      sourcePath: path,
+      targetUrl,
+      status: response.status
+    });
+
+    return new Response(body, {
+      status: response.status,
+      headers
+    });
+  } catch (error) {
+    const status = error?.name === 'AbortError' ? 504 : 502;
+    logProxy({
+      sourcePath: path,
+      targetUrl,
+      status,
+      error: error instanceof Error ? error.message : String(error)
+    });
+
+    return new Response(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }), {
+      status,
+      headers: { 'content-type': 'application/json', 'access-control-allow-origin': ALLOW_ORIGIN }
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+addEventListener('fetch', event => {
+  event.respondWith(handleRequest(event.request));
+});

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,92 +1,87 @@
-// Cloudflare Worker for NBA CORS proxy
+// Cloudflare Worker (ES Modules) for NBA CORS proxy
 // Routes: /nba/scoreboard, /nba/scoreboard/:date, /nba/playbyplay/:gameId, /nba/schedule/:date
 
-const ALLOW_ORIGIN = '*';
-const FETCH_TIMEOUT_MS = 8000;
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    const path = url.pathname;
+    const ALLOW_ORIGIN = '*';
+    const FETCH_TIMEOUT_MS = 8000;
 
-function logProxy(entry) {
-  console.log(JSON.stringify({ at: new Date().toISOString(), ...entry }));
-}
+    // Handle CORS preflight
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 204,
+        headers: {
+          'access-control-allow-origin': ALLOW_ORIGIN,
+          'access-control-allow-methods': 'GET,OPTIONS',
+          'access-control-allow-headers': 'content-type'
+        }
+      });
+    }
 
-async function handleRequest(request) {
-  const url = new URL(request.url);
-  const path = url.pathname;
+    let targetUrl;
 
-  // Handle CORS preflight
-  if (request.method === 'OPTIONS') {
-    return new Response(null, {
-      status: 204,
-      headers: {
-        'access-control-allow-origin': ALLOW_ORIGIN,
-        'access-control-allow-methods': 'GET,OPTIONS',
-        'access-control-allow-headers': 'content-type'
-      }
-    });
+    if (path === '/nba/scoreboard') {
+      targetUrl = 'https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json';
+    } else if (path.match(/^\/nba\/scoreboard\/\d{8}$/)) {
+      const gameDate = path.split('/').pop();
+      targetUrl = `https://cdn.nba.com/static/json/liveData/scoreboard/scoreboard_${gameDate}.json`;
+    } else if (path.match(/^\/nba\/playbyplay\/[^/]+$/)) {
+      const gameId = path.split('/').pop();
+      targetUrl = `https://cdn.nba.com/static/json/liveData/playbyplay/playbyplay_${gameId}.json`;
+    } else if (path.match(/^\/nba\/schedule\/\d{8}$/)) {
+      const dateKey = path.split('/').pop();
+      targetUrl = `https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?dates=${dateKey}`;
+    } else {
+      return new Response(JSON.stringify({ error: 'Not found' }), {
+        status: 404,
+        headers: { 'content-type': 'application/json' }
+      });
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(targetUrl, {
+        headers: { 'user-agent': 'even-nba-pulse-proxy/1.0' },
+        signal: controller.signal
+      });
+
+      const body = await response.text();
+      const headers = new Headers(response.headers);
+      headers.set('access-control-allow-origin', ALLOW_ORIGIN);
+      headers.set('access-control-allow-methods', 'GET,OPTIONS');
+      headers.set('access-control-allow-headers', 'content-type');
+
+      console.log(JSON.stringify({
+        at: new Date().toISOString(),
+        sourcePath: path,
+        targetUrl,
+        status: response.status
+      }));
+
+      return new Response(body, {
+        status: response.status,
+        headers
+      });
+    } catch (error) {
+      const status = error?.name === 'AbortError' ? 504 : 502;
+      console.log(JSON.stringify({
+        at: new Date().toISOString(),
+        sourcePath: path,
+        targetUrl,
+        status,
+        error: error instanceof Error ? error.message : String(error)
+      }));
+
+      return new Response(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }), {
+        status,
+        headers: { 'content-type': 'application/json', 'access-control-allow-origin': ALLOW_ORIGIN }
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
   }
-
-  let targetUrl;
-
-  if (path === '/nba/scoreboard') {
-    targetUrl = 'https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json';
-  } else if (path.match(/^\/nba\/scoreboard\/\d{8}$/)) {
-    const gameDate = path.split('/').pop();
-    targetUrl = `https://cdn.nba.com/static/json/liveData/scoreboard/scoreboard_${gameDate}.json`;
-  } else if (path.match(/^\/nba\/playbyplay\/[^/]+$/)) {
-    const gameId = path.split('/').pop();
-    targetUrl = `https://cdn.nba.com/static/json/liveData/playbyplay/playbyplay_${gameId}.json`;
-  } else if (path.match(/^\/nba\/schedule\/\d{8}$/)) {
-    const dateKey = path.split('/').pop();
-    targetUrl = `https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?dates=${dateKey}`;
-  } else {
-    return new Response(JSON.stringify({ error: 'Not found' }), {
-      status: 404,
-      headers: { 'content-type': 'application/json' }
-    });
-  }
-
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
-  try {
-    const response = await fetch(targetUrl, {
-      headers: { 'user-agent': 'even-nba-pulse-proxy/1.0' },
-      signal: controller.signal
-    });
-
-    const body = await response.text();
-    const headers = new Headers(response.headers);
-    headers.set('access-control-allow-origin', ALLOW_ORIGIN);
-    headers.set('access-control-allow-methods', 'GET,OPTIONS');
-    headers.set('access-control-allow-headers', 'content-type');
-
-    logProxy({
-      sourcePath: path,
-      targetUrl,
-      status: response.status
-    });
-
-    return new Response(body, {
-      status: response.status,
-      headers
-    });
-  } catch (error) {
-    const status = error?.name === 'AbortError' ? 504 : 502;
-    logProxy({
-      sourcePath: path,
-      targetUrl,
-      status,
-      error: error instanceof Error ? error.message : String(error)
-    });
-
-    return new Response(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }), {
-      status,
-      headers: { 'content-type': 'application/json', 'access-control-allow-origin': ALLOW_ORIGIN }
-    });
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
-
-addEventListener('fetch', event => {
-  event.respondWith(handleRequest(event.request));
-});
+};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+  "name": "nba-pulse-proxy",
+  "compatibility_date": "2026-04-25",
+  "main": "worker/index.js"
+}


### PR DESCRIPTION
## Summary
Fix play-by-play normalization and Cloudflare Worker deployment for NBA Pulse Even Hub app.

---

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Build / packaging
- [ ] Test improvement

---

## What Changed
- Fixed `normalizeActions()` in `src/lib/nbaApi.js` to map NBA play-by-play data instead of returning empty array
- Added `wrangler.jsonc` configuration for Cloudflare Worker deployment
- Created `worker/index.js` with ES Modules syntax (required for Cloudflare Versions API)
- Bumped version from 0.2.4 to 0.2.5

---

## Why This Change
The play-by-play timeline was not displaying because `normalizeActions()` was a stub returning `[]`. Additionally, Cloudflare Pages deployment was failing due to:
1. Missing `wrangler.jsonc` config file
2. Worker using old Service Worker syntax (`addEventListener`) instead of ES Modules (`export default`)

These fixes enable:
- Live play-by-play events to display on G2 glasses
- Successful Cloudflare Worker deployment via `npx wrangler versions upload`